### PR TITLE
id overhaul, new optional settings dict, default file mode w

### DIFF
--- a/ex1.py
+++ b/ex1.py
@@ -28,7 +28,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from pykron.core import AsyncRequest
+from pykron.core import AsyncRequest, PykronLogger
 import pykron
 import time
 import logging

--- a/pykron/core.py
+++ b/pykron/core.py
@@ -37,14 +37,58 @@ import pandas as pd
 import os
 import sys
 import logging
+import logging.config
+import logging.handlers
 import atexit
 import linecache
 import traceback
 
 atexit.unregister(concurrent.futures.thread._python_exit)
 
-
 class PykronLogger:
+    LOGGING_SETTINGS = None
+    LOGGING_SETTINGS_JSON = {
+        'version': 1,
+        'disable_existing_loggers': True,
+        'formatters': {
+            'json': {
+                'format': '{"asctime": "%(asctime)-15s", "created": %(created)f, "relativeCreated": %(relativeCreated)f, "levelname": "%(levelname)s", "module": "%(module)s", "process": %(process)d, "processName": "%(processName)s", "thread": %(thread)d, "threadName": "%(threadName)s", "message": "%(message)s"}'
+            },
+            'verbose': {
+                'format': '%(asctime)s - %(levelname)s - %(module)s - %(process)d - %(thread)d - %(message)s'
+            },
+            'simple': {
+                'format': '%(asctime)s - %(levelname)s - %(message)s'
+            },
+        },
+        'handlers': {
+            'file': {
+                'level':'DEBUG',
+                'class':'logging.FileHandler',
+                # this works, but only in a configfile:
+                #'filename': (__import__('datetime').datetime.now().strftime('log/pykron_%%Y-%%m-%%d_%%H-%%M-%%S.log'), 'a'),
+                'filename': 'pykron.log',
+                'mode': 'w',
+                'formatter': 'json'
+            },
+            'console': {
+                'level':'DEBUG',
+                'class':'logging.StreamHandler',
+                'formatter': 'simple'
+            }
+        },
+        'loggers': {
+            'default': {
+                'handlers': ['console', 'file'],
+                'level': 'DEBUG'
+            }
+        },
+        'root': {
+                'handlers': ['console', 'file'],
+                'level': 'DEBUG'
+        }
+    }
+
     FORMAT = '%(asctime)s - %(levelname)s - %(message)s'
     LOGGING_LEVEL = logging.DEBUG
     LOGGING_PATH = None
@@ -61,21 +105,35 @@ class PykronLogger:
             raise Exception("This class is a singleton!")
         else:
             PykronLogger._instance = self
-            self._logger = logging.getLogger('pykron')
-            self._logger.setLevel(PykronLogger.LOGGING_LEVEL)
-            if not PykronLogger.LOGGING_PATH is None:
-                filename = os.path.join(PykronLogger.LOGGING_PATH, 'pykron.log')
-                ch = logging.FileHandler(filename)
+            if PykronLogger.LOGGING_SETTINGS is None:
+                self._logger = logging.getLogger('pykron')
+                self._logger.setLevel(PykronLogger.LOGGING_LEVEL)
+                if not PykronLogger.LOGGING_PATH is None:
+                    filename = os.path.join(PykronLogger.LOGGING_PATH, 'pykron.log')
+                    ch = logging.FileHandler(filename, mode='w')
+                else:
+                    ch = logging.StreamHandler()
+                ch.setLevel(PykronLogger.LOGGING_LEVEL)
+                formatter = logging.Formatter(PykronLogger.FORMAT)
+                ch.setFormatter(formatter)
+                self._logger.addHandler(ch)
             else:
-                ch = logging.StreamHandler()
-            ch.setLevel(PykronLogger.LOGGING_LEVEL)
-            formatter = logging.Formatter(PykronLogger.FORMAT)
-            ch.setFormatter(formatter)
-            self._logger.addHandler(ch)
+                logging.config.dictConfig(PykronLogger.LOGGING_SETTINGS)
+                self._logger = logging.getLogger('pykron')
+            self._task_id = 0
 
     @property
     def log(self):
        return self._logger
+
+    # get_native_id is not unique and not readable easily during the ongoing execution
+    # this solution has the advantage of being consecutive
+    _id_lock = threading.Lock()
+    def getNewId(self):
+        with self._id_lock:
+            self._task_id += 1
+            return self._task_id
+
 
 class Task:
 
@@ -89,7 +147,7 @@ class Task:
 
     EXECUTIONS = {}
 
-    def __init__(self, target, args, timeout=TIMEOUT_DEFAULT, name=None):
+    def __init__(self, target, args, timeout=TIMEOUT_DEFAULT, name=None, thread_parent=''):
         self._target = target
         self._args = args
         self._timeout = timeout
@@ -99,8 +157,8 @@ class Task:
         self._end_ts = None
         self._duration = None
         self._exception = None
-        self._task_id = threading.get_native_id()
         self._logger = PykronLogger.getInstance()
+        self._thread_parent = thread_parent
 
         if name:
             self._name = name
@@ -172,10 +230,12 @@ class Task:
     def run(self):
         self._start_ts = time.perf_counter()
         self._status = Task.RUNNING
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        self._task_id = self._logger.getNewId() # this is an incrementing id
+        thread_name_prefix = threading.current_thread().name + '_T' + str(self._task_id)
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1,thread_name_prefix=thread_name_prefix)
         waitForShutdown = True
         try:
-            self._logger.log.debug("T%d: Starting task %s() " % (self._task_id, self._name))
+            self._logger.log.debug("T%d: Starting task %s() by %s " % (self._task_id, self._name, self._thread_parent))
             future = executor.submit(self._target, *self._args)
             t = future.result(timeout=self._timeout)
             self._retval = t
@@ -210,7 +270,8 @@ class AsyncRequest:
             def f(*args, **kwargs):
                 task = Task(target=foo,
                             args=args,
-                            timeout=timeout)
+                            timeout=timeout,
+                            thread_parent=threading.current_thread().name)
                 req = AsyncRequest(task)
                 return req
             return f
@@ -252,8 +313,9 @@ class AsyncRequest:
         self._task = task
         self._timeout = task.timeout
         self._callback = None
+        self._thread_name_prefix = threading.current_thread().name
         self._logger = PykronLogger.getInstance()
-        self._executor = concurrent.futures.ThreadPoolExecutor()
+        self._executor = concurrent.futures.ThreadPoolExecutor(thread_name_prefix=self._thread_name_prefix)
         self._future = self._executor.submit(self.run)
 
     @property


### PR DESCRIPTION
Reasons:
get_native_id is not useful when the thread has not started yet, so tracking a dependency tree for threads becomes problematic
also, for readability - unique and consecutive id is quicker to match when the console output is moving
I think we can move to (some_thread).native_id from (some_thread).name if we overhaul the launching a bit and make the Task also carry over the proper native_id... but again, they will not be unique and will get reused by the system

the dictionary config is temporary, should be moved actually to a couple of optional configfiles, in order to allow for example a rolling config with names "pykron-20201103-1518.log"
